### PR TITLE
Considera describe mais interno

### DIFF
--- a/evaluator.js
+++ b/evaluator.js
@@ -15,7 +15,7 @@ const { requirements } = JSON.parse(requirementsFile);
 const evaluationsByRequirements =
   testResults.map(({ assertionResults }) => (
     assertionResults.map(({ ancestorTitles, status }) => ({
-      describe: ancestorTitles[0],
+      describe: ancestorTitles[ancestorTitles.length - 1],
       status
     }))
   )).flat()


### PR DESCRIPTION
- Este PR faz com que o avaliador considere o describe mais interno para poder fazer o devido mapeamento com o requisito. Ou seja, considerando o seguinte exemplo:
```js
describe('a', () => {
  describe('b', () => {
    describe('c', () => {
      it('my test', () => {
        expect(1 + 2).toBe(3);
      });
    });
  });
});
```
O avaliador atual escolheria `'a'` como a mensagem para mapear ao requisito. Neste PR, o avaliador escolheria `'c'`.