### PR TITLE
feat: adiciona possibilidade de executar npm start antes da avaliação

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ GitHub specific branch
 
 ### `npm-start`
 
-Run npm start and waits to http://localhost:3000 before testing
+Run npm start and waits to url before testing
+
+### `wait-for`
+
+Url that npm start command waits for
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ GitHub repository that store the tests
 
 GitHub specific branch
 
+### `npm-start`
+
+Run npm start and waits to http://localhost:3000 before testing
+
 ## Outputs
 
 ### `result`
@@ -30,6 +34,7 @@ Pull Request number that trigger build.
   with:
     repository-test-name: my-org/my-repo
     repository-test-branch: master # master is default
+    npm-start: true # false is default
 ```
 
 ## How to get result output

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Pull Request number that trigger build.
     repository-test-name: my-org/my-repo
     repository-test-branch: master # master is default
     npm-start: true # false is default
+    wait-for: 'http://localhost:8080' # http://localhost:3000 is default
 ```
 
 ## How to get result output

--- a/action.yml
+++ b/action.yml
@@ -9,8 +9,11 @@ inputs:
     default: 'master'
     required: true
   npm-start:
-    description: 'Run npm start and waits to http://localhost:3000 before testing'
+    description: 'Run npm start and waits to url before testing'
     default: false
+  wait-for:
+    description: 'Url that npm start command waits for'
+    default: 'http://localhost:3000'
 outputs:
   result:
     description: 'Jest unit tests JSON results in base64 format.'
@@ -23,3 +26,4 @@ runs:
     - ${{ inputs.repository-test-name }}
     - ${{ inputs.repository-test-branch }}
     - ${{ inputs.npm-start }}
+    - ${{ inputs.wait-for }}

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: 'GitHub specific branch'
     default: 'master'
     required: true
+  npm-start:
+    description: 'Run npm start and waits to http://localhost:3000 before testing'
+    default: false
 outputs:
   result:
     description: 'Jest unit tests JSON results in base64 format.'
@@ -19,3 +22,4 @@ runs:
   args:
     - ${{ inputs.repository-test-name }}
     - ${{ inputs.repository-test-branch }}
+    - ${{ inputs.npm-start }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,7 @@ set -x
 REPOSITORY_NAME=$1
 REPOSITORY_BRANCH=$2
 run_npm_start=$3
+wait_for_url=$4
 
 git clone --branch $REPOSITORY_BRANCH https://github.com/$REPOSITORY_NAME.git /project-tests
 rm -rf /project-tests/.git
@@ -12,7 +13,7 @@ npm install
 
 if $run_npm_start ; then
   npm install -g wait-on
-  npm start & wait-on http://localhost:3000
+  npm start & wait-on $wait_for_url
 fi
 
 npm test -- --json --outputFile=evaluation.json

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,8 +12,7 @@ cp -r /project-tests/* .
 npm install
 
 if $run_npm_start ; then
-  npm install -g wait-on
-  npm start & wait-on $wait_for_url
+  npm start & npx wait-on $wait_for_url
 fi
 
 npm test -- --json --outputFile=evaluation.json

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,11 +3,18 @@ set -x
 
 REPOSITORY_NAME=$1
 REPOSITORY_BRANCH=$2
+run_npm_start=$3
 
 git clone --branch $REPOSITORY_BRANCH https://github.com/$REPOSITORY_NAME.git /project-tests
 rm -rf /project-tests/.git
 cp -r /project-tests/* .
 npm install
+
+if $run_npm_start ; then
+  npm install -g wait-on
+  npm start & wait-on http://localhost:3000
+fi
+
 npm test -- --json --outputFile=evaluation.json
 node /evaluator.js evaluation.json .trybe/requirements.json result.json
 


### PR DESCRIPTION
Alguns projetos dos blocos de NodeJS podem (depende de como os testes serão implementados) necessitar da execução do comando `npm start` (para subir uma API, ou para iniciar uma aplicação _frontend_) antes da avaliação.