### PR TITLE
Prepara avaliador para versão segura

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - 12
-
-script:
-  - npm test

--- a/README.md
+++ b/README.md
@@ -26,10 +26,8 @@ Pull Request number that trigger build.
 ## Usage example
 
 ```yml
-- uses: betrybe/jest-evaluator-action@v3
+- uses: betrybe/jest-evaluator-action@v8
   with:
-    repository-test-name: my-org/my-repo
-    repository-test-branch: master # master is default
     npm-start: true # false is default
     wait-for: 'http://localhost:8080' # http://localhost:3000 is default
 ```
@@ -38,7 +36,7 @@ Pull Request number that trigger build.
 ```yml
 - name: Jest evaluator
   id: evaluator
-  uses: betrybe/jest-evaluator-action@v3
+  uses: betrybe/jest-evaluator-action@v8
 - name: Next step
   uses: another-github-action
   with:

--- a/README.md
+++ b/README.md
@@ -5,14 +5,6 @@ This action evaluate Tryber projects with [Jest](https://jestjs.io/) library.
 
 ## Inputs
 
-### `repository-test-name`
-
-GitHub repository that store the tests
-
-### `repository-test-branch`
-
-GitHub specific branch
-
 ### `npm-start`
 
 Run npm start and waits to url before testing

--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,6 @@ inputs:
 outputs:
   result:
     description: 'Jest unit tests JSON results in base64 format.'
-  pr-number:
-    description: 'Pull Request number that trigger build.'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -1,13 +1,6 @@
 name: 'Jest evaluator'
 description: 'Jest evaluator action for Tryber projects'
 inputs:
-  repository-test-name:
-    description: 'GitHub repository that store the tests'
-    required: true
-  repository-test-branch:
-    description: 'GitHub specific branch'
-    default: 'master'
-    required: true
   npm-start:
     description: 'Run npm start and waits to url before testing'
     default: false
@@ -23,7 +16,5 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.repository-test-name }}
-    - ${{ inputs.repository-test-branch }}
     - ${{ inputs.npm-start }}
     - ${{ inputs.wait-for }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,9 @@
 #!/bin/sh -l
 set -x
 
-REPOSITORY_NAME=$1
-REPOSITORY_BRANCH=$2
-run_npm_start=$3
-wait_for_url=$4
+run_npm_start=$1
+wait_for_url=$2
 
-git clone --branch $REPOSITORY_BRANCH https://github.com/$REPOSITORY_NAME.git /project-tests
-rm -rf /project-tests/.git
-cp -r /project-tests/* .
 npm install
 
 if $run_npm_start ; then
@@ -24,4 +19,3 @@ if [ $? != 0 ]; then
 fi
 
 echo ::set-output name=result::`cat result.json | base64 -w 0`
-echo ::set-output name=pr-number::$(echo "$GITHUB_REF" | awk -F / '{print $3}')


### PR DESCRIPTION
- remove a clonagem e copia do repositório de testes
- remove o _output_ prNumber pois a api do GitHub já dispõe desse valor e não é necessário coleta-lo através do avaliador.