### PR TITLE
imp: recebe username como input

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Run npm start and waits to url before testing
 
 Url that npm start command waits for
 
+### `pr_author_username`
+
+Pull Request author username
+
 ## Outputs
 
 ### `result`

--- a/README.md
+++ b/README.md
@@ -5,32 +5,36 @@ This action evaluate Tryber projects with [Jest](https://jestjs.io/) library.
 
 ## Inputs
 
-### `npm-start`
+- `npm-start`
 
-Run npm start and waits to url before testing
+  Optional
 
-### `wait-for`
+  Run npm start and waits to url before testing.
 
-Url that npm start command waits for
+- `wait-for`
 
-### `pr_author_username`
+  Optional
 
-Pull Request author username
+  Url that npm start command waits for
+
+- `pr_author_username`
+
+  **Required**
+
+  Pull Request author username.
 
 ## Outputs
 
-### `result`
+- `result`
 
-Jest unit tests JSON results in base64 format.
-
-### `pr-number`
-
-Pull Request number that trigger build.
+  Jest unit tests JSON results in base64 format.
 
 ## Usage example
 
 ```yml
 - uses: betrybe/jest-evaluator-action@v8
+  with:
+    pr_author_username: ${{ github.event.inputs.pr_author_username }}
   with:
     npm-start: true # false is default
     wait-for: 'http://localhost:8080' # http://localhost:3000 is default
@@ -41,6 +45,8 @@ Pull Request number that trigger build.
 - name: Jest evaluator
   id: evaluator
   uses: betrybe/jest-evaluator-action@v8
+  with:
+    pr_author_username: ${{ github.event.inputs.pr_author_username }}
 - name: Next step
   uses: another-github-action
   with:

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   wait-for:
     description: 'Url that npm start command waits for'
     default: 'http://localhost:3000'
+  pr_author_username:
+    description: 'Pull Request author username'
+    required: true
 outputs:
   result:
     description: 'Jest unit tests JSON results in base64 format.'

--- a/evaluator.js
+++ b/evaluator.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const CORRECT_ANSWER_GRADE = 3;
 const WRONG_ANSWER_GRADE = 1;
 
-const githubUsername = process.env.GITHUB_ACTOR || 'no_actor';
+const githubUsername = process.env.INPUT_PR_AUTHOR_USERNAME || 'no_actor';
 const githubRepositoryName = process.env.GITHUB_REPOSITORY || 'no_repository';
 
 const jestOuputFile = fs.readFileSync(process.argv[2]);


### PR DESCRIPTION
Devido as alterações na [LEARN-869](https://trybe.atlassian.net/browse/LEARN-869?atlOrigin=eyJpIjoiNDZlNGJlYTljYzM2NDRhZmI0OGU3Njk1MGYwZGJmN2UiLCJwIjoiaiJ9), no qual o _workflow_ é executado via `dispatch`, a _envvar_ `GITHUB_ACTOR` é o Github App de Selfhosted então é necessário passar o **username** via **input**.