### PR TITLE
Build version image

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,7 +1,9 @@
 name: ECR evaluator image
 on:
   push:
-    branches: [master]
+    branches: [build-version-image]
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -24,7 +26,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.EKS_ACCESS_KEY_ID  }}
+          aws-access-key-id: ${{ secrets.EKS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.EKS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.EKS_REGION }}
           mask-aws-account-id: "no"
@@ -35,4 +37,4 @@ jobs:
       - name: Build Docker Image
         uses: betrybe/trybe-image-builder@main
         with:
-          imageTag: ${{ github.event.inputs.version }}
+          imageTag: v9

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,4 +1,4 @@
-name: ECR evaluator image
+name: Build and push image to Dockerhub
 on:
   workflow_dispatch:
     inputs:
@@ -6,9 +6,6 @@ on:
         description: "Versão do avaliador que você deseja fazer o build"
         required: true
         default: "latest"
-
-env:
-  REPOSITORY: jest-evaluator-action
 
 jobs:
   build:
@@ -19,18 +16,15 @@ jobs:
         with:
           ref: ${{ github.event.inputs.version }}
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1.12.0
         with:
-          aws-access-key-id: ${{ secrets.EKS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.EKS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.EKS_REGION }}
-          mask-aws-account-id: "no"
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
-      - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Build Docker Image
-        uses: betrybe/trybe-image-builder@main
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.7.0
         with:
-          imageTag: ${{ github.event.inputs.version }}
+          context: .
+          push: true
+          tags: betrybe/jest-evaluator-action:${{ github.event.inputs.version }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,38 @@
+name: ECR evaluator image
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Versão do avaliador que você deseja fazer o build"
+        required: true
+        default: "latest"
+
+env:
+  REPOSITORY: jest-evaluator-action
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.version }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.EKS_ACCESS_KEY_ID  }}
+          aws-secret-access-key: ${{ secrets.EKS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.EKS_REGION }}
+          mask-aws-account-id: "no"
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build Docker Image
+        uses: betrybe/trybe-image-builder@main
+        with:
+          imageTag: ${{ github.event.inputs.version }}

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -1,10 +1,7 @@
-name: ECR evaluator image release
+name: Build and push image to Dockerhub on release
 on:
   release:
     types: [published]
-
-env:
-  REPOSITORY: jest-evaluator-action
 
 jobs:
   build:
@@ -18,18 +15,15 @@ jobs:
       - name: Set release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1.12.0
         with:
-          aws-access-key-id: ${{ secrets.EKS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.EKS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.EKS_REGION }}
-          mask-aws-account-id: "no"
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
-      - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Build Docker Image
-        uses: betrybe/trybe-image-builder@main
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.7.0
         with:
-          imageTag: ${{ env.RELEASE_VERSION }}
+          context: .
+          push: true
+          tags: betrybe/jest-evaluator-action:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -1,11 +1,7 @@
-name: ECR evaluator image
+name: ECR evaluator image release
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Versão do avaliador que você deseja fazer o build"
-        required: true
-        default: "latest"
+  release:
+    types: [published]
 
 env:
   REPOSITORY: jest-evaluator-action
@@ -17,7 +13,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.inputs.version }}
+          ref: ${{ github.ref }}
+
+      - name: Set release version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -33,4 +32,4 @@ jobs:
       - name: Build Docker Image
         uses: betrybe/trybe-image-builder@main
         with:
-          imageTag: ${{ github.event.inputs.version }}
+          imageTag: ${{ env.RELEASE_VERSION }}

--- a/action.yml
+++ b/action.yml
@@ -10,10 +10,6 @@ inputs:
   pr_author_username:
     description: 'Pull Request author username'
     required: true
-  version:
-    description: 'Evaluator version to use'
-    required: true
-    default: latest
 
 outputs:
   result:
@@ -21,7 +17,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 992764703785.dkr.ecr.us-east-2.amazonaws.com/jest-evaluator-action:${{ inputs.version }}
+  image: 'Dockerfile'
   args:
     - ${{ inputs.npm-start }}
     - ${{ inputs.wait-for }}

--- a/action.yml
+++ b/action.yml
@@ -10,12 +10,18 @@ inputs:
   pr_author_username:
     description: 'Pull Request author username'
     required: true
+  version:
+    description: 'Evaluator version to use'
+    required: true
+    default: latest
+
 outputs:
   result:
     description: 'Jest unit tests JSON results in base64 format.'
+
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 992764703785.dkr.ecr.us-east-2.amazonaws.com/jest-evaluator-action:${{ inputs.version }}
   args:
     - ${{ inputs.npm-start }}
     - ${{ inputs.wait-for }}


### PR DESCRIPTION
Conforme [thread](https://betrybe.slack.com/archives/C01Q3PY8LLW/p1638549528400200) foi identificado que alguns projetos passam mais tempo em build por estarem fazendo build do docker toda vez que o avaliador roda. Para melhorar este processo estamos fazendo push da imagem no docker e vamos apenas fazer pull (ao invés de build toda vez). 

Esta PR faz o build e push da imagem para o Dockerhub toda vez que uma nova release do projeto é feita. Também adiciona a opção de fazer isso manualmente via _workflow_dispatch_.