### PR TITLE
imp: usa imagem ao invés do Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Jest evaluator action for Tryber projects
 
 This action evaluate Tryber projects with [Jest](https://jestjs.io/) library.
 
+**WARNING:** the image docker version specified in the `action.yml` must be the same as the last evaluator release version
+
 ## Inputs
 
 - `npm-start`

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://betrybe/jest-evaluator-action:v9.1'
   args:
     - ${{ inputs.npm-start }}
     - ${{ inputs.wait-for }}


### PR DESCRIPTION
Conforme discutido na [thread](https://betrybe.slack.com/archives/C01Q3PY8LLW/p1641836637018200?thread_ts=1638549528.400200&cid=C01Q3PY8LLW)  a solução feita fazia com que fosse necessário mudar o arquivo de workflow de todos os projetos vigentes, para evitar isso usamos a imagem direto no avaliador, continua evitando o build (que levava tempo), mas sem precisar de alguma mudança nos projetos.