### PR TITLE
fix: adiciona 4GB como valor máximo de memória alocado para o Nodejs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://betrybe/jest-evaluator-action:v9.1'
+  image: 'docker://betrybe/jest-evaluator-action:v9.2'
   args:
     - ${{ inputs.npm-start }}
     - ${{ inputs.wait-for }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,7 @@ set -x
 run_npm_start=$1
 wait_for_url=$2
 
+export NODE_OPTIONS=--max_old_space_size=4096
 npm install
 
 if $run_npm_start ; then


### PR DESCRIPTION
### Problema
- Em alguns projetos, o nodejs usa mais memória do que o alocado por default e lança um error de _**Heap of memory**_
### Solução
- Definir manualmente um novo valor de memória a ser alocado
### Link
- [[BUG] Avaliador automático - Projeto Solar System](https://trybe.atlassian.net/browse/LEARN-3997)
- [Action Rodando a nova imagem do jest-evaluator](https://github.com/betrybe/test-jest-evaluator/runs/5159420435?check_suite_focus=true)
- [Docker image v9.2](https://hub.docker.com/layers/betrybe/jest-evaluator-action/v9.2/images/sha256-89348bd3c83302ed1b5d3f0ba767b9e77ef9465befcd5350a053cf2a25df02d9?context=explore)