### PR TITLE
Altera avaliador para funcionar com describes aninhados

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://betrybe/jest-evaluator-action:v9.4'
+  image: 'docker://betrybe/jest-evaluator-action:igorg-teste-logs'
   args:
     - ${{ inputs.npm-start }}
     - ${{ inputs.wait-for }}

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://betrybe/jest-evaluator-action:igorg-teste-logs'
+  image: 'docker://betrybe/jest-evaluator-action:v9.5'
   args:
     - ${{ inputs.npm-start }}
     - ${{ inputs.wait-for }}

--- a/evaluator.js
+++ b/evaluator.js
@@ -20,7 +20,7 @@ const evaluationsByRequirements = testResults
       return ancestorTitles.map((describe) => ({ describe, status }));
     })
   )
-  .flat()
+  .flat(2)
   .reduce((acc, evaluation) => {
     const status = acc[evaluation.describe];
     const currentStatus = evaluation.status;

--- a/evaluator.js
+++ b/evaluator.js
@@ -9,7 +9,7 @@ const githubRepositoryName = process.env.GITHUB_REPOSITORY || 'no_repository';
 const jestOuputFile = fs.readFileSync(process.argv[2]);
 const { testResults } = JSON.parse(jestOuputFile);
 
-console.log(testResults)
+console.log("testResults ->", JSON.stringify(testResults))
 
 const requirementsFile = fs.readFileSync(process.argv[3]);
 const { requirements } = JSON.parse(requirementsFile);
@@ -37,7 +37,7 @@ const evaluations =
       grade: (evaluationsByRequirements[description] === 'passed') ? CORRECT_ANSWER_GRADE : WRONG_ANSWER_GRADE
     }));
 
-    console.log(evaluationsByRequirements)
+    console.log("evaluationsByRequirements ->", JSON.stringify(evaluationsByRequirements))
 
 fs.writeFileSync(process.argv[4], JSON.stringify({
   github_username: githubUsername,

--- a/evaluator.js
+++ b/evaluator.js
@@ -9,40 +9,48 @@ const githubRepositoryName = process.env.GITHUB_REPOSITORY || 'no_repository';
 const jestOuputFile = fs.readFileSync(process.argv[2]);
 const { testResults } = JSON.parse(jestOuputFile);
 
-console.log("testResults ->", JSON.stringify(testResults))
+console.log('testResults ->', JSON.stringify(testResults));
 
 const requirementsFile = fs.readFileSync(process.argv[3]);
 const { requirements } = JSON.parse(requirementsFile);
 
-const evaluationsByRequirements =
-  testResults.map(({ assertionResults }) => (
-    assertionResults.map(({ ancestorTitles, status }) => ({
-      describe: ancestorTitles[ancestorTitles.length - 1],
-      status
-    }))
-  )).flat()
-    .reduce((acc, evaluation) => {
-      const status = acc[evaluation.describe];
-      const currentStatus = evaluation.status;
-      if (!status || currentStatus === 'failed') {
-        acc[evaluation.describe] = currentStatus;
-        return acc;
-      }
+const evaluationsByRequirements = testResults
+  .map(({ assertionResults }) =>
+    assertionResults.map(({ ancestorTitles, status }) => {
+      return ancestorTitles.map((describe) => ({ describe, status }));
+    })
+  )
+  .flat()
+  .reduce((acc, evaluation) => {
+    const status = acc[evaluation.describe];
+    const currentStatus = evaluation.status;
+    if (!status || currentStatus === 'failed') {
+      acc[evaluation.describe] = currentStatus;
       return acc;
-    }, {});
+    }
+    return acc;
+  }, {});
 
-const evaluations =
-    requirements.map(({ description }) => ({
-      description,
-      grade: (evaluationsByRequirements[description] === 'passed') ? CORRECT_ANSWER_GRADE : WRONG_ANSWER_GRADE
-    }));
-
-    console.log("evaluationsByRequirements ->", JSON.stringify(evaluationsByRequirements))
-
-fs.writeFileSync(process.argv[4], JSON.stringify({
-  github_username: githubUsername,
-  github_repository_name: githubRepositoryName,
-  evaluations: [...evaluations]
+const evaluations = requirements.map(({ description }) => ({
+  description,
+  grade:
+    evaluationsByRequirements[description] === 'passed'
+      ? CORRECT_ANSWER_GRADE
+      : WRONG_ANSWER_GRADE,
 }));
+
+console.log(
+  'evaluationsByRequirements ->',
+  JSON.stringify(evaluationsByRequirements)
+);
+
+fs.writeFileSync(
+  process.argv[4],
+  JSON.stringify({
+    github_username: githubUsername,
+    github_repository_name: githubRepositoryName,
+    evaluations: [...evaluations],
+  })
+);
 
 process.exit();

--- a/evaluator.js
+++ b/evaluator.js
@@ -9,6 +9,8 @@ const githubRepositoryName = process.env.GITHUB_REPOSITORY || 'no_repository';
 const jestOuputFile = fs.readFileSync(process.argv[2]);
 const { testResults } = JSON.parse(jestOuputFile);
 
+console.log(testResults)
+
 const requirementsFile = fs.readFileSync(process.argv[3]);
 const { requirements } = JSON.parse(requirementsFile);
 
@@ -35,6 +37,7 @@ const evaluations =
       grade: (evaluationsByRequirements[description] === 'passed') ? CORRECT_ANSWER_GRADE : WRONG_ANSWER_GRADE
     }));
 
+    console.log(evaluationsByRequirements)
 
 fs.writeFileSync(process.argv[4], JSON.stringify({
   github_username: githubUsername,

--- a/evaluator.js
+++ b/evaluator.js
@@ -9,8 +9,6 @@ const githubRepositoryName = process.env.GITHUB_REPOSITORY || 'no_repository';
 const jestOuputFile = fs.readFileSync(process.argv[2]);
 const { testResults } = JSON.parse(jestOuputFile);
 
-console.log('testResults ->', JSON.stringify(testResults));
-
 const requirementsFile = fs.readFileSync(process.argv[3]);
 const { requirements } = JSON.parse(requirementsFile);
 
@@ -38,11 +36,6 @@ const evaluations = requirements.map(({ description }) => ({
       ? CORRECT_ANSWER_GRADE
       : WRONG_ANSWER_GRADE,
 }));
-
-console.log(
-  'evaluationsByRequirements ->',
-  JSON.stringify(evaluationsByRequirements)
-);
 
 fs.writeFileSync(
   process.argv[4],


### PR DESCRIPTION
Em função [desta issue](https://github.com/betrybe/conteudo-modular-desenvolvimento-web/issues/2850) aberta no repo do LMS percebemos que caso os testes avaliativos precisem usar _describes_ aninhados teriamos uma falha no feedback.

Foi realizado um ajuste no `evaluator.js` para que o retorno da função **evaluationsByRequirements** continuasse funcionando corretamente mesmo em um cenário com _describes_ aninhados.